### PR TITLE
Improve error handling and logging for network stream

### DIFF
--- a/RuneRebirth2005/ClientManagement/Client.cs
+++ b/RuneRebirth2005/ClientManagement/Client.cs
@@ -28,15 +28,24 @@ public class Client
     {
         Server.Players[Index] = new Player();
         Socket.Close();
-        Console.WriteLine($"Client {Index} disconnected. Reason: {reason}");
+        Log.Information($"Client {Index} disconnected. Reason: {reason}");
     }
 
     public void FillStream(int count)
     {
+        if (!NetworkStream.CanRead)
+        {
+            return;
+        }
         try
         {
             Reader.CurrentOffset = 0;
-            NetworkStream.Read(Reader.Buffer, 0, count);
+            var bytes = NetworkStream.Read(Reader.Buffer, 0, count);
+
+            if (bytes < count)
+            {
+                throw new IOException("we couldn't read enough bytes");
+            }
         }
         catch (IOException ex)
         {
@@ -50,6 +59,10 @@ public class Client
 
     public void FlushBufferedData()
     {
+        if (!NetworkStream.CanWrite)
+        {
+            return;
+        }
         try
         {
             NetworkStream.Write(Writer.Buffer, 0, Writer.CurrentOffset);

--- a/RuneRebirth2005/Entities/Player.cs
+++ b/RuneRebirth2005/Entities/Player.cs
@@ -62,9 +62,16 @@ public class Player : Client, IEntity
     {
         var directoryPath = "Data/Characters";
         var filePath = $"{directoryPath}/{Username}.json";
-        
-        using FileStream openStream = File.OpenRead(filePath);
-        Data = JsonSerializer.Deserialize<PlayerData>(openStream);
-        Log.Information($"Loaded player data for: {Username}.");
+
+        if (File.Exists(filePath))
+        {
+            using FileStream openStream = File.OpenRead(filePath);
+            Data = JsonSerializer.Deserialize<PlayerData>(openStream);
+            Log.Information($"Loaded player data for: {Username}.");
+        }
+        else
+        {
+            SavePlayer();
+        }
     }
 }

--- a/RuneRebirth2005/PlayerManagement/PlayerManager.cs
+++ b/RuneRebirth2005/PlayerManagement/PlayerManager.cs
@@ -18,7 +18,7 @@ public static class PlayerManager
             Reader = new RSStream(new byte[ServerConfig.BUFFER_SIZE]),
             Writer = new RSStream(new byte[ServerConfig.BUFFER_SIZE])
         };
-
+        Log.Information($"Initialized new Player");
         return player;
     }
 

--- a/RuneRebirth2005/Server/ServerEngine.cs
+++ b/RuneRebirth2005/Server/ServerEngine.cs
@@ -79,6 +79,7 @@ public class ServerEngine
         foreach (var player in Server.Players)
         {
             if (player.Index == -1) continue;
+            Log.Information($"Going to flush data to: {player.Username}");
             player.FlushBufferedData();
         }
         


### PR DESCRIPTION
This commit introduces several enhancements to better handle network streams and increase error logging. Firstly, it has made changes to Check NetworkStream for its readability and writeability before any operation. It also throws an IOException if not enough bytes are read from the stream. Further, the PacketHandler class was refactored to better support state-based handling. The Player initialization now also includes a check if a player data file exists and creates it if not. Logging has been increased and improved across to better troubleshoot or understand what is happening during runtime. These changes increase the stability, readability, and debugging ability of the network layer for the game server.