### PR TITLE
Refactor packet handling and player registration logic

### DIFF
--- a/RuneRebirth2005/PlayerManagement/PlayerManager.cs
+++ b/RuneRebirth2005/PlayerManagement/PlayerManager.cs
@@ -19,7 +19,6 @@ public static class PlayerManager
             Reader = new RSStream(new byte[ServerConfig.BUFFER_SIZE]),
             Writer = new RSStream(new byte[ServerConfig.BUFFER_SIZE])
         };
-        Log.Information($"Initialized new Player");
         return player;
     }
 
@@ -42,10 +41,10 @@ public static class PlayerManager
 
     public static void AssignAvailablePlayerSlot(Player player)
     {
-        for (var i = 1; i < Server.Players.Length; i++)
+        for (var i = 0; i < Server.Players.Length; i++)
             if (Server.Players[i].Index == -1)
             {
-                player.Index = i;
+                player.Index = i + 1;
                 Log.Information($"Incoming connection has been assigned index: {player.Index}!");
                 return;
             }
@@ -57,7 +56,7 @@ public static class PlayerManager
 
     public static void RegisterPlayer(Player player)
     {
-        Server.Players[player.Index] = player;
+        Server.Players[player.Index - 1] = player;
         Log.Information($"Client with ID: [{player.Index}] has been registered!");
     }
 

--- a/RuneRebirth2005/Server/ServerEngine.cs
+++ b/RuneRebirth2005/Server/ServerEngine.cs
@@ -67,10 +67,15 @@ public class ServerEngine
 
         /* Process Incoming Data */
         // Log.Information("Processing fetched data..");
+
+        foreach (var player in Server.Players)
+        {
+            player.PacketStore.ProcessPackets();
+        }
+        
         foreach (var player in Server.Players)
         {
             if (player.Index == -1) continue;
-            player.PacketStore.ProcessPackets();
             new PlayerUpdatePacket(player).Add();
         }
 
@@ -79,7 +84,7 @@ public class ServerEngine
         foreach (var player in Server.Players)
         {
             if (player.Index == -1) continue;
-            Log.Information($"Going to flush data to: {player.Username}");
+            //Log.Information($"Going to flush data to: {player.Data.Username}");
             player.FlushBufferedData();
         }
         


### PR DESCRIPTION
Changes made to streamline packet handling logic by eliminating unnecessary checks and maintaining a clean, private instance of the Player within PacketHandler. The logic for player registration is slightly tweaked for zero-based array compatibility - the loop for assigning available player slot now starts at zero instead of one, and the index is incremented by one accordingly. Logging statements have also been adjusted for a user-friendly output.

Also fixed bug where it wouldn't process until the next tick.